### PR TITLE
docs updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,9 @@ After decades managing engineering teams at eBay, Amazon, and Airbus, I realized
 
 The recommended way to use Glyphcard is through the MCP server:
 
-# Claude Code setup instructions here
-[integration/claude_code_setup.md](../integration/claude_code_setup.md)
-
-# VS Code Setup instructions here
-[integration/vs_code_setup.md](integration/vs_code_setup.md)
-
-```bash
-# Claude Code Setup
-integration/claude_code_setup.md
-
-#VS Code Setup
-integration/vs_code_setup.md
-```
+Setup guides:
+- Claude Code: [integration/claude_code_setup.md](integration/claude_code_setup.md)
+- VSCode: [integration/vscode_setup.md](integration/vscode_setup.md)
 
 Then use MCP tools in your AI agent:
 - `start_work()` - Pick up and orient on next available card

--- a/integration/claude_code_setup.md
+++ b/integration/claude_code_setup.md
@@ -4,10 +4,11 @@ This guide shows how to set up the Glyphcard MCP server in Claude Code CLI.
 
 ## Prerequisites
 
-- Claude Code CLI installed
-- Python 3.12+
+- [Claude Code CLI installed](https://www.claude.com/product/claude-code )
+- [Python 3.12+](https://www.python.org/downloads/)
 - Glyphcard repository cloned
-- Virtual environment created and dependencies installed
+- [Virtual environment created and dependencies installed](https://www.freecodecamp.org/news/how-to-setup-virtual-environments-in-python/)
+
 
 ## Setup Steps
 


### PR DESCRIPTION
* Updated the `README.md` to replace the previous code block setup instructions with a clearer list of setup guides, providing direct links to the integration guides for Claude Code and VSCode.

Setup guide enhancements:

* Improved the `integration/claude_code_setup.md` prerequisites section by converting plain text items into clickable links for installing Claude Code CLI, Python 3.12+, and creating a Python virtual environment, making it easier for users to access relevant resources.