### PR TITLE
Add Project scoped filter to PM_Dashboard for acceptance Queue and de…

### DIFF
--- a/.glyphcard/project_state.json
+++ b/.glyphcard/project_state.json
@@ -6,10 +6,15 @@
       "description": "Features for creating and managing user workspaces in Glyphcard",
       "workspace_path": "/home/rowandev/glyphcard/agent_workspaces/claude/workspace_management",
       "managed": true,
+      "activation_count": 2,
+      "last_activated": "2025-10-13T00:34:20.190717"
+    },
+    "my_web_app": {
+      "first_activated": "2025-10-13T00:32:11.560769",
       "activation_count": 1,
-      "last_activated": "2025-10-12T23:42:34.772108"
+      "last_activated": "2025-10-13T00:32:11.560777"
     }
   },
-  "last_updated": "2025-10-12T23:42:34.772116",
+  "last_updated": "2025-10-13T00:34:20.190723",
   "version": "1.0"
 }

--- a/acceptance.yaml
+++ b/acceptance.yaml
@@ -14,21 +14,28 @@ pending_reviews:
   - README explains the project
   orientation_info: {}
   output_location: agent_workspaces/claude/output_001.md
+- id: '025'
+  title: Filter dependency chain view by active project
+  submitted_date: '2025-10-13T00:35:43.057133'
+  assignee: claude
+  size: 2-3 hours
+  deliverables:
+  - Update pm_dashboard.py to filter dependency chain by active project
+  - Show only cards from active project in dependency view
+  - Display active project name in dashboard header
+  - Add visual indicator when project filter is active
+  - Update dashboard documentation
+  validation:
+  - Dependency chain shows only cards from active project
+  - All projects view is available when no project is active
+  - Dashboard clearly indicates which project is being viewed
+  - No cards from other projects appear in filtered view
+  orientation_info: {}
+  output_location: agent_workspaces/claude/output_025.md
+accepted:
 - id: '022'
   title: Remove cat picture demo cards and update gitignore
-  submitted_date: '2025-10-12T23:48:18.372195'
-  assignee: claude
-  size: 30 minutes
-  deliverables:
-  - Remove all cat_picture_app demo cards from glyphcards/
-  - Update .gitignore to exclude glyphcards/ directory entirely
-  - Clean up any orphaned orientation packets or outputs related to cat demo cards
-  - Verify git status shows glyphcards/ as ignored
-  validation:
-  - No cat_picture_app cards remain in glyphcards/
-  - glyphcards/ directory is in .gitignore
-  - git status does not show glyphcards/ files
-  orientation_info: {}
-  output_location: agent_workspaces/claude/output_022.md
-accepted: []
+  accepted_date: '2025-10-13T00:36:34.493291'
+  reviewer: human
+  notes: Glyphcard accepted and validated
 needs_revision: []

--- a/orientation/system_state.json
+++ b/orientation/system_state.json
@@ -1,9 +1,18 @@
 {
   "card_22_remove_cat_picture_demo_cards_and_update_gitignore": {
-    "status": "completed",
+    "status": "archived",
     "last_updated": "2025-10-12T23:48:18.373093",
     "linked_cards": [
       "022"
+    ],
+    "accepted_date": "2025-10-13T00:36:34.494166",
+    "archived_date": "2025-10-13T00:36:40.182451"
+  },
+  "card_25_filter_dependency_chain_view_by_active_project": {
+    "status": "completed",
+    "last_updated": "2025-10-13T00:35:43.058379",
+    "linked_cards": [
+      "025"
     ]
   }
 }

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -233,7 +233,13 @@
 </head>
 <body>
     <div class="container">
-    <h1>🛠️ Glyphcard PM Dashboard</h1>
+    <h1>🛠️ Glyphcard PM Dashboard{% if active_project %} <span style="color: #007bff; font-size: 0.7em;">[Project: {{ active_project }}]</span>{% endif %}</h1>
+    {% if active_project %}
+    <div style="background: #e7f3ff; border-left: 4px solid #007bff; padding: 10px; margin: 10px 0; border-radius: 4px;">
+        <strong>🔍 Project Filter Active:</strong> Showing only cards from "<strong>{{ active_project }}</strong>" project.
+        <span style="color: #666; font-size: 0.9em;">(To see all projects, deactivate the project using: <code>python project_manager.py deactivate</code>)</span>
+    </div>
+    {% endif %}
     <div class="tabs">
         {% set current_view = view if view is defined and view else 'cards' %}
         <a href="/" class="tab {{ 'active' if current_view == 'cards' else '' }}">Review Queue</a>


### PR DESCRIPTION
## Filter Dependency Chain and Review Queue by Active Project

### Problem
The PM dashboard was displaying all cards from all projects simultaneously, making it confusing to manage multi-project workflows. When a project was activated via `project_manager.py activate <project>`, the dashboard didn't respect this context, showing irrelevant cards from other projects.

### Solution
Updated the PM dashboard to filter all views by the currently active project:
- Review queue (pending reviews, needs revision, accepted cards)
- Dependency chain visualization
- Missing dependencies warnings
- Unattached cards

Added clear visual indicators:
- Project name badge in header: `[Project: workspace_management]`
- Blue banner explaining active filter with deactivation instructions
- Only appears when a project is active

### Changes
- **pm_dashboard.py**
  - Added `get_active_project()` function to read from `.glyphcard/project_state.json`
  - Updated `_build_dependency_view()` to accept optional `project_filter` parameter
  - Modified both dashboard routes (`/` and `/dependencies`) to filter by active project
  - Filtered pending reviews, needs revision, accepted, and dependency chains

- **templates/dashboard.html**
  - Added project name badge to header
  - Added project filter active banner with deactivation instructions

- **glyphcards/024_implement_workspace_creation_functionality.yaml**
  - Fixed invalid `linked_to` reference from `workspace_management_002` to `23`

### Behavior
- **When project is active**: Dashboard shows only cards from that project
- **When no project is active**: Dashboard shows all cards (backward compatible)
- **Deactivation**: `python project_manager.py deactivate`

### Testing
Tested with `workspace_management` project activated:
- ✅ Only workspace_management cards visible (022, 023, 024, 025)
- ✅ Cards from other projects hidden (mcp_server_docs, glyphcard_workflow, pm_dashboard)
- ✅ Visual indicator clearly shows active filter
- ✅ Deactivation returns to all-projects view