### PR TITLE
Add MCP server and dashboard tests

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,265 @@
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import yaml
+
+try:  # pragma: no cover - import shim to satisfy test environment
+    import fastmcp  # type: ignore  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover - exercised in CI without fastmcp
+    class DummyFastMCP:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def tool(self, func):
+            return func
+
+    dummy_fastmcp = ModuleType("fastmcp")
+    dummy_fastmcp.FastMCP = DummyFastMCP
+    sys.modules["fastmcp"] = dummy_fastmcp
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import mcp_server
+
+
+def call_tool(tool, *args, **kwargs):
+    """Invoke an MCP tool regardless of FastMCP wrapping."""
+    target = getattr(tool, "fn", tool)
+    return target(*args, **kwargs)
+
+
+def test_get_orientation_context_internal_missing_packet(monkeypatch, tmp_path):
+    """Missing orientation packet should return an explicit error."""
+    monkeypatch.setattr(mcp_server.workflow, "orientation_dir", tmp_path)
+
+    result = mcp_server._get_orientation_context_internal("999")
+
+    assert "error" in result
+    assert "not found" in result["error"]
+
+
+def test_get_orientation_context_internal_with_packet(monkeypatch, tmp_path):
+    """Orientation packets are parsed with truncated review notes."""
+    orientation_dir = tmp_path / "orientation"
+    orientation_dir.mkdir()
+    packet_path = orientation_dir / "orientation_packet_027.yaml"
+    long_notes = "note" * 200  # 800 characters to trigger truncation
+    packet_data = {
+        "card_id": "027",
+        "title": "Test Card",
+        "deliverables": ["Demo deliverable"],
+        "validation": ["Run pytest"],
+        "context_brief": {"context_needs": ["Need context"]},
+        "open_questions": [],
+        "review_notes": [{"notes": long_notes}],
+    }
+    packet_path.write_text(yaml.dump(packet_data))
+    monkeypatch.setattr(mcp_server.workflow, "orientation_dir", orientation_dir)
+
+    result = mcp_server._get_orientation_context_internal("027")
+
+    assert result["card_id"] == "027"
+    assert result["title"] == "Test Card"
+    assert result["has_review_notes"] is True
+    assert result["review_notes_summary"].endswith("...")
+    assert len(result["review_notes_summary"]) <= 503
+
+
+def test_discover_available_work_filters_by_project_and_dependencies(monkeypatch):
+    """Only unblocked cards in the active project should be marked available."""
+    state = {
+        27: {"blocked": False, "parents": [], "missing_parents": [], "pending_parents": []},
+        28: {"blocked": True, "parents": ["026"], "missing_parents": [], "pending_parents": ["026"]},
+        30: {"blocked": False, "parents": [], "missing_parents": [], "pending_parents": []},
+    }
+    entries = [
+        {
+            "id": 27,
+            "id_str": "027",
+            "data": {
+                "id": 27,
+                "title": "Ready Card",
+                "status": "available",
+                "assigned_to": "claude",
+                "project": "workspace_management",
+                "size": "2-4 hours",
+                "review_notes": [],
+            },
+        },
+        {
+            "id": 28,
+            "id_str": "028",
+            "data": {
+                "id": 28,
+                "title": "Blocked Card",
+                "status": "available",
+                "assigned_to": "claude",
+                "project": "workspace_management",
+                "size": "2-4 hours",
+                "review_notes": [],
+            },
+        },
+        {
+            "id": 30,
+            "id_str": "030",
+            "data": {
+                "id": 30,
+                "title": "Other Agent Card",
+                "status": "available",
+                "assigned_to": "someone_else",
+                "project": "workspace_management",
+                "size": "2-4 hours",
+                "review_notes": [],
+            },
+        },
+        {
+            "id": 31,
+            "id_str": "031",
+            "data": {
+                "id": 31,
+                "title": "Other Project Card",
+                "status": "available",
+                "assigned_to": "claude",
+                "project": "another_project",
+                "size": "2-4 hours",
+                "review_notes": [],
+            },
+        },
+    ]
+
+    monkeypatch.setattr(mcp_server, "compute_dependency_state", lambda: (state, entries))
+    monkeypatch.setattr(mcp_server.workflow.project_manager, "get_active_project", lambda: "workspace_management")
+
+    result = mcp_server._discover_available_work_internal()
+
+    assert result["available_cards"] == [
+        {"id": 27, "title": "Ready Card", "status": "available", "size": "2-4 hours", "project": "workspace_management", "has_review_notes": False}
+    ]
+    assert result["blocked_cards"] == [
+        {"id": 28, "title": "Blocked Card", "status": "available", "size": "2-4 hours", "project": "workspace_management", "has_review_notes": False}
+    ]
+    assert result["count"] == 1
+    assert result["blocked_count"] == 1
+
+
+def test_start_work_returns_waiting_when_only_blocked(monkeypatch):
+    """When no cards are available, the tool should indicate a waiting state."""
+    monkeypatch.setattr(
+        mcp_server,
+        "_discover_available_work_internal",
+        lambda: {
+            "available_cards": [],
+            "blocked_cards": [{"id": 99, "title": "Blocked"}],
+            "count": 0,
+            "blocked_count": 1,
+        },
+    )
+
+    result = call_tool(mcp_server.start_work)
+
+    assert result["action"] == "waiting"
+    assert "No work available" in result["message"]
+
+
+def test_start_work_runs_reorienter_on_available_card(monkeypatch):
+    """Available cards should trigger the reorienter script with the padded ID."""
+    monkeypatch.setattr(
+        mcp_server,
+        "_discover_available_work_internal",
+        lambda: {
+            "available_cards": [{"id": 27, "title": "Card Title", "status": "available", "size": "2-4 hours", "project": "workspace_management", "has_review_notes": False}],
+            "blocked_cards": [],
+            "count": 1,
+            "blocked_count": 0,
+        },
+    )
+    captured = {}
+
+    def fake_run(cmd, capture_output, text, cwd):
+        captured["cmd"] = cmd
+        captured["cwd"] = cwd
+        captured["capture_output"] = capture_output
+        captured["text"] = text
+        return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(mcp_server.subprocess, "run", fake_run)
+
+    result = call_tool(mcp_server.start_work)
+
+    assert result["action"] == "started"
+    assert result["card_id"] == "27"
+    assert captured["cmd"][0] == sys.executable
+    assert captured["cmd"][1] == str(mcp_server.workflow.orientation_dir / "reorienter.py")
+    assert captured["cmd"][3] == "027"
+    assert captured["capture_output"] is True
+    assert captured["text"] is True
+    assert captured["cwd"] == str(mcp_server.workflow.base_dir)
+
+
+def test_check_dependencies_reports_pending_and_modules(monkeypatch, tmp_path):
+    """Dependency checks surface linked cards, pending status, and module progress."""
+    orientation_dir = tmp_path / "orientation"
+    orientation_dir.mkdir()
+    packet_path = orientation_dir / "orientation_packet_27.yaml"
+    packet_data = {
+        "card_id": "027",
+        "title": "Card with Modules",
+        "deliverables": [],
+        "validation": [],
+        "context_brief": {
+            "linked_modules": {
+                "sync_module": {"status": "in_progress", "linked_cards": ["040"]},
+                "docs_module": {"status": "completed", "linked_cards": []},
+            },
+        },
+        "open_questions": [],
+        "review_notes": [],
+    }
+    packet_path.write_text(yaml.dump(packet_data))
+    monkeypatch.setattr(mcp_server.workflow, "orientation_dir", orientation_dir)
+
+    state = {
+        27: {
+            "blocked": True,
+            "parents": ["026"],
+            "missing_parents": [],
+            "pending_parents": ["026"],
+        },
+        26: {
+            "blocked": False,
+            "parents": [],
+            "missing_parents": [],
+            "pending_parents": [],
+        },
+    }
+    entries = [
+        {
+            "id": 27,
+            "id_str": "027",
+            "data": {"id": 27, "title": "Card with Modules", "status": "in_progress"},
+        },
+        {
+            "id": 26,
+            "id_str": "026",
+            "data": {"id": 26, "title": "Parent Card", "status": "submitted"},
+        },
+    ]
+
+    monkeypatch.setattr(mcp_server, "compute_dependency_state", lambda: (state, entries))
+
+    result = call_tool(mcp_server.check_dependencies, "27")
+
+    assert result["card_id"] == "27"
+    assert result["dependencies_met"] is False
+    dependency_types = {dep["type"] for dep in result["dependencies"]}
+    assert dependency_types == {"linked_card", "module"}
+    linked_card = next(dep for dep in result["dependencies"] if dep["type"] == "linked_card")
+    assert linked_card["card_id"] == "026"
+    assert linked_card["met"] is False
+    module_entries = [dep for dep in result["dependencies"] if dep["type"] == "module"]
+    assert {mod["module_name"] for mod in module_entries} == {"sync_module", "docs_module"}
+    sync_module = next(mod for mod in module_entries if mod["module_name"] == "sync_module")
+    assert sync_module["met"] is False

--- a/tests/test_pm_dashboard.py
+++ b/tests/test_pm_dashboard.py
@@ -1,0 +1,57 @@
+import sys
+from types import ModuleType, SimpleNamespace
+
+try:  # pragma: no cover - allow running tests without Flask installed
+    import flask  # type: ignore  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover
+    flask_stub = ModuleType("flask")
+
+    class DummyFlask:
+        def __init__(self, *args, **kwargs):
+            self.config = {}
+
+        def route(self, *args, **kwargs):
+            def decorator(func):
+                return func
+            return decorator
+
+    flask_stub.Flask = DummyFlask
+    flask_stub.render_template = lambda *args, **kwargs: ""
+    flask_stub.request = SimpleNamespace(form={}, args={})
+    flask_stub.jsonify = lambda *args, **kwargs: {}
+    flask_stub.redirect = lambda value, *args, **kwargs: value
+    flask_stub.url_for = lambda *args, **kwargs: ""
+    sys.modules["flask"] = flask_stub
+
+import pm_dashboard
+
+
+def test_normalize_card_id_handles_numeric_and_strings():
+    assert pm_dashboard._normalize_card_id(7) == "007"
+    assert pm_dashboard._normalize_card_id("42") == "042"
+    assert pm_dashboard._normalize_card_id("0042") == "042"
+    assert pm_dashboard._normalize_card_id("abc") == "abc"
+    assert pm_dashboard._normalize_card_id("") is None
+    assert pm_dashboard._normalize_card_id(None) is None
+
+
+def test_build_dependency_view_filters_projects_and_flags_missing(monkeypatch):
+    sample_cards = [
+        {"_id_str": "023", "_linked_to_str": None, "project": "workspace_management", "title": "Workspace Parent"},
+        {"_id_str": "027", "_linked_to_str": "023", "project": "workspace_management", "title": "Workspace Child"},
+        {"_id_str": "031", "_linked_to_str": "999", "project": "workspace_management", "title": "Missing Link"},
+        {"_id_str": "030", "_linked_to_str": None, "project": "other_project", "title": "Other Project"},
+    ]
+    monkeypatch.setattr(pm_dashboard, "_load_all_glyphcards", lambda: sample_cards)
+
+    trees, missing_links, unattached = pm_dashboard._build_dependency_view(project_filter="workspace_management")
+
+    root_ids = {tree["card_id"] for tree in trees}
+    assert root_ids == {"023", "031"}
+
+    parent_node = next(tree for tree in trees if tree["card_id"] == "023")
+    child_ids = [child["card_id"] for child in parent_node["children"]]
+    assert child_ids == ["027"]
+
+    assert missing_links == [{"card": sample_cards[2], "missing_id": "999"}]
+    assert unattached == []


### PR DESCRIPTION
Title: Add MCP server and dashboard tests 

  Summary:

  - add tests/test_mcp_server.py to cover orientation parsing, work discovery, start-work paths, and dependency reporting while unwrapping FastMCP tool wrappers
  - add tests/test_pm_dashboard.py to verify _normalize_card_id handling and _build_dependency_view project filtering/missing-link reporting with a Flask shim
  - document the broader coverage and CI guidance in the existing CI readiness notes

  Validation: pytest